### PR TITLE
Updated to rc.5 compability

### DIFF
--- a/ExpandedStomach/CommandHandler.cs
+++ b/ExpandedStomach/CommandHandler.cs
@@ -158,6 +158,7 @@ namespace ExpandedStomach
                 playername = args.Parsers[0].IsMissing ? "" : args.Parsers[0].GetValue().ToString();
             if (playername == "")
                 playername = args.Caller.Player.PlayerName;
+            string upperPlayername = playername.ToUpper();
             IPlayer[] allplayers;
             if (serverAPI != null) allplayers = serverAPI.World.AllOnlinePlayers;
             else allplayers = clientAPI.World.AllOnlinePlayers;
@@ -165,7 +166,7 @@ namespace ExpandedStomach
             IPlayer thePlayer = null;
             foreach (var player in allplayers)
             {
-                if (player.PlayerName == playername)
+                if (player.PlayerName.ToUpper() == upperPlayername)
                 {
                     thePlayer = player;
                     playerFound = true;
@@ -173,27 +174,27 @@ namespace ExpandedStomach
                 }
             }
             if (!playerFound) return TextCommandResult.Error("Player not found.");
-            if(serverAPI != null)
+            StringBuilder sb = new StringBuilder();
+            if (serverAPI != null)
             {
                 var stomach = thePlayer.Entity.GetBehavior<EntityBehaviorStomach>();
-                StringBuilder sb = new StringBuilder();
+                sb.AppendLine("Information for " + playername + ":");
                 sb.AppendLine("Stomach Level/Size: " + stomach.ExpandedStomachMeter.ToString() + "/" + stomach.StomachSize.ToString());
                 sb.AppendLine("Stomach Cap info: Today's cap: " + stomach.ExpandedStomachCapToday.ToString() + "   Average Cap: " + stomach.ExpandedStomachCapAverage.ToString());
                 sb.AppendLine("Fat Level: " + (stomach.FatMeter * 100).ToString() + "%");
                 sb.AppendLine("Strain Values: Current: " + stomach.strain.ToString() + "   Average: " + stomach.averagestrain.ToString() + "   Last: " + stomach.laststrain.ToString());
-                return TextCommandResult.Success(sb.ToString());
             }
             else
             {
                 // grab information from watched attributes instead
                 var stomach = thePlayer.Entity.WatchedAttributes.GetTreeAttribute("expandedStomach");
-                StringBuilder sb = new StringBuilder();
+                sb.AppendLine("Information for " + playername + ":");
                 sb.AppendLine("Stomach Level/Size: " + stomach.GetFloat("expandedStomachMeter").ToString() + "/" + stomach.GetInt("stomachSize").ToString());
                 sb.AppendLine("Stomach Cap info: Today's cap: " + stomach.GetFloat("expandedStomachCapToday").ToString() + "   Average Cap: " + stomach.GetFloat("expandedStomachCapAverage").ToString());
                 sb.AppendLine("Fat Level: " + (stomach.GetFloat("fatMeter") * 100).ToString() + "%");
                 sb.AppendLine("Strain Values: Current: " + stomach.GetFloat("strain").ToString() + "   Average: " + stomach.GetFloat("averagestrain").ToString() + "   Last: " + stomach.GetFloat("laststrain").ToString());
-                return TextCommandResult.Success(sb.ToString());
             }
+            return TextCommandResult.Success(sb.ToString());
         }
 
         internal TextCommandResult SetConfig(TextCommandCallingArgs args)

--- a/ExpandedStomach/Config/ConfigServer.cs
+++ b/ExpandedStomach/Config/ConfigServer.cs
@@ -64,6 +64,10 @@ namespace ExpandedStomach
         public string overstuffedthdescription => "Percentage of stomach saturation needed to be overstuffed. (default 90%)";
         [JsonProperty(Order = 26)]
         public float overStuffedThreshold { get; set; } = 0.9f;
+        [JsonProperty(Order = 27)]
+        public string fatLostToHungerMultiplierDescription => "Multiply how much fat is lost when fending off hunger. (default 100%)";
+        [JsonProperty(Order = 28)]
+        public float fatLostToHungerMultiplier { get; set; } = 1f;
 
         public ConfigServer(ICoreAPI api, ConfigServer previousConfig = null)
         {
@@ -85,6 +89,7 @@ namespace ExpandedStomach
             barVerticalOffset = previousConfig.barVerticalOffset;
             overStuffedTimeDelay = previousConfig.overStuffedTimeDelay;
             overStuffedThreshold = previousConfig.overStuffedThreshold;
+            fatLostToHungerMultiplier = previousConfig.fatLostToHungerMultiplier;
         }
     }
 }

--- a/ExpandedStomach/ExpandedStomachModSystem.cs
+++ b/ExpandedStomach/ExpandedStomachModSystem.cs
@@ -28,7 +28,7 @@ public class ExpandedStomachModSystem : ModSystem
 
     public static bool AdjustBarLocation { get; private set; }
     public static bool EFACAactive { get; private set; }
-    public HudESBar hudESBar;
+    public static HudESBar hudESBar;
     Harmony sHarmony;
     Harmony cHarmony;
 
@@ -45,7 +45,7 @@ public class ExpandedStomachModSystem : ModSystem
     public override void StartPre(ICoreAPI api)
     {
         api.RegisterEntityBehaviorClass("expandedStomach", typeof(EntityBehaviorStomach));
-        sHarmony = new Harmony("expandedstomach");
+        sHarmony = new Harmony("expandedstomach.server");
         cHarmony = new Harmony("expandedstomach.client");
     }
 
@@ -54,13 +54,17 @@ public class ExpandedStomachModSystem : ModSystem
         if(api == null)
         {
             api = serverapi;
-            setupConfig(api);
+            if (api != null)
+                setupConfig(api);
             api = clientapi;
-            setupConfig(api);
+            if (api != null)
+                setupConfig(api);
             api = coreapi;
-            setupConfig(api);
+            if (api != null)
+                setupConfig(api);
         }
         else setupConfig(api);
+        hudESBar?.ComposeBarGUI(); //update bar just in case the config changed
     }
 
     public static void setupConfig(ICoreAPI api)
@@ -81,6 +85,7 @@ public class ExpandedStomachModSystem : ModSystem
         api.World.Config.SetFloat("ExpandedStomach.barVerticalOffset", sConfig.barVerticalOffset);
         api.World.Config.SetInt("ExpandedStomach.overStuffedTimeDelay", sConfig.overStuffedTimeDelay);
         api.World.Config.SetFloat("ExpandedStomach.overStuffedThreshold", sConfig.overStuffedThreshold);
+        api.World.Config.SetFloat("ExpandedStomach.fatLostToHungerMultiplier", sConfig.fatLostToHungerMultiplier);
     }
 
     public override void StartServerSide(ICoreServerAPI api)
@@ -126,6 +131,7 @@ public class ExpandedStomachModSystem : ModSystem
                 EFACAactive = true;
             }
             ServerPatcher.ApplyServerPatches(sHarmony);
+            Patch_HungerDamageTicks.ApplyCorePatches(sHarmony);
             serverPatched = true;
         }
         //check for HungerPatcher
@@ -195,7 +201,7 @@ public class ExpandedStomachModSystem : ModSystem
 
     public override void Dispose()
     {
-        sHarmony?.UnpatchAll("expandedstomach");
+        sHarmony?.UnpatchAll("expandedstomach.server");
         cHarmony?.UnpatchAll("expandedstomach.client");
         serverPatched = false;
         clientPatched = false;

--- a/ExpandedStomach/HarmonyPatches/Patch_EatingControl.cs
+++ b/ExpandedStomach/HarmonyPatches/Patch_EatingControl.cs
@@ -57,8 +57,8 @@ namespace ExpandedStomach.HarmonyPatches
             MethodInfo setSatPrefix = AccessTools.Method(typeof(Patch_EntityBehaviorHunger_set_Saturation), nameof(Patch_EntityBehaviorHunger_set_Saturation.Prefix));
             harmony.Patch(setSat, prefix: new HarmonyMethod(setSatPrefix));
             // EBBTemperature OnGameTick
-            MethodInfo EBBTonGameTick = AccessTools.Method(typeof(EntityBehaviorBodyTemperature), "OnGameTick");
-            MethodInfo EBBTonGameTickTranspiler = AccessTools.Method(typeof(Patch_EntityBehaviorBodyTemperature_OnGameTick), nameof(Patch_EntityBehaviorBodyTemperature_OnGameTick.Transpiler));
+            MethodInfo EBBTonGameTick = AccessTools.Method(typeof(EntityBehaviorBodyTemperature), "updateBodyTemperature");
+            MethodInfo EBBTonGameTickTranspiler = AccessTools.Method(typeof(Patch_EntityBehaviorBodyTemperature_UpdateBodyTemperature), nameof(Patch_EntityBehaviorBodyTemperature_UpdateBodyTemperature.Transpiler));
             harmony.Patch(EBBTonGameTick, transpiler: new HarmonyMethod(EBBTonGameTickTranspiler));
             // EBHunger ReduceSaturation
             MethodInfo EBHRedSat = AccessTools.Method(typeof(EntityBehaviorHunger), "ReduceSaturation");
@@ -159,7 +159,7 @@ namespace ExpandedStomach.HarmonyPatches
             {
                 if ((codes[i].opcode == OpCodes.Callvirt && //if it's a call to a virtual method
                     codes[i].operand.ToString().Contains("ReceiveSaturation")) && //and it's a call to ReceiveSaturation
-                    codes[i + 1].opcode == OpCodes.Ldloc_1) // and the very next instruction is Ldloc_1
+                    codes[i + 1].opcode == OpCodes.Ldarg_3) // and the very next instruction is Ldarg_3
                 {
                     // then we found it!
                     RecieveSaturationIndex = i;
@@ -315,7 +315,7 @@ namespace ExpandedStomach.HarmonyPatches
     #endregion
 
     #region EntityBehaviorBodyTemperature_OnGameTick
-    public static class Patch_EntityBehaviorBodyTemperature_OnGameTick
+    public static class Patch_EntityBehaviorBodyTemperature_UpdateBodyTemperature
     {
         public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator il)
         {
@@ -327,9 +327,9 @@ namespace ExpandedStomach.HarmonyPatches
             for (int i = 2; i < codes.Count; i++)
             {
                 if (
-                    codes[i - 2].opcode == OpCodes.Ldloc_S && codes[i - 2].operand is LocalBuilder lb1 && lb1.LocalIndex == 12 &&
+                    codes[i - 2].opcode == OpCodes.Ldloc_S && codes[i - 2].operand is LocalBuilder lb1 && lb1.LocalIndex == 7 &&
                     codes[i - 1].opcode == OpCodes.Sub &&
-                    codes[i].opcode == OpCodes.Stloc_S && codes[i].operand is LocalBuilder lb2 && lb2.LocalIndex == 13
+                    codes[i].opcode == OpCodes.Stloc_S && codes[i].operand is LocalBuilder lb2 && lb2.LocalIndex == 8
                 )
                 {
                     // Inject after i (the stloc.s 13)
@@ -350,9 +350,9 @@ namespace ExpandedStomach.HarmonyPatches
             var toInject = new List<CodeInstruction>
             {
                 new CodeInstruction(OpCodes.Ldarg_0),
-                new CodeInstruction(OpCodes.Ldloc_S, 13),
+                new CodeInstruction(OpCodes.Ldloc_S, 8),
                 new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(Helpers), "ModifyHereTemperature")),
-                new CodeInstruction(OpCodes.Stloc_S, 13)
+                new CodeInstruction(OpCodes.Stloc_S, 8)
             };
 
             codes.InsertRange(originalCallIndex, toInject);

--- a/ExpandedStomach/HarmonyPatches/Patch_HungerDamageTicks.cs
+++ b/ExpandedStomach/HarmonyPatches/Patch_HungerDamageTicks.cs
@@ -1,0 +1,78 @@
+﻿using HarmonyLib;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+using Vintagestory.API.Common;
+using Vintagestory.API.Common.Entities;
+using Vintagestory.GameContent;
+
+namespace ExpandedStomach.HarmonyPatches
+{
+    public static class Patch_HungerDamageTicks
+    {
+        public static void ApplyCorePatches(Harmony harmony)
+        {
+            MethodInfo EntityRD = (MethodInfo)IForgotToBringFoodWithMe.TargetMethod();
+            MethodInfo EntityRDPrefix = AccessTools.Method(typeof(IForgotToBringFoodWithMe), nameof(IForgotToBringFoodWithMe.Prefix));
+            harmony.Patch(EntityRD, prefix: new HarmonyMethod(EntityRDPrefix));
+        }
+    }
+
+    public static class IForgotToBringFoodWithMe
+    {
+        public static MethodBase TargetMethod()
+        {
+            return AccessTools.Method(typeof(Entity), "ReceiveDamage");
+        }
+
+        public static bool Prefix(Entity __instance, DamageSource damageSource, ref float damage)
+        {
+            if(damageSource.Type == EnumDamageType.Hunger && __instance is EntityPlayer player)
+            {
+                //magic happens
+                EntityBehaviorStomach stomach = player.GetBehavior<EntityBehaviorStomach>();
+                if(stomach != null)
+                {
+                    if (!stomach.currentlyFendingOffHungerWithFatLoss 
+                        && stomach.fatToBeLostToHunger == 0)
+                    {
+                        float currentfat = stomach.FatMeter;
+                        stomach.fatToBeLostToHunger = currentfat * 0.1f;
+                        stomach.totalFatLostToHunger = 0;
+                        stomach.hungerStavedByFatLoss = 0;
+                        stomach.currentlyFendingOffHungerWithFatLoss = true;
+                    }
+                    if (stomach.currentlyFendingOffHungerWithFatLoss) //if system is active
+                    {
+                        float fatToBeLost = 0.0005f * stomach.fatLostToHungerMultiplier;
+                        //TODO: adjust fatToBeLost based on mod difficulty level in config because I hate myself
+                        //
+                        // -- END TODO
+                        float fatThatCanBeLost = stomach.fatToBeLostToHunger - stomach.totalFatLostToHunger;
+                        if (fatThatCanBeLost < fatToBeLost)
+                        {
+                            stomach.FatMeter -= fatToBeLost;
+                            stomach.hungerStavedByFatLoss += damage;
+                            if (stomach.hungerStavedByFatLoss > 20f)
+                                stomach.hungerStavedByFatLoss = 20f;
+                            damage = stomach.hungerStavedByFatLoss;
+                            stomach.currentlyFendingOffHungerWithFatLoss = false;
+                        }
+                        else
+                        {
+                            stomach.totalFatLostToHunger += fatToBeLost;
+                            stomach.hungerStavedByFatLoss += damage;
+                            if(stomach.hungerStavedByFatLoss > 20f)
+                                stomach.hungerStavedByFatLoss = 20f;
+                            damage = 0;
+                            stomach.FatMeter -= fatToBeLost;
+                        }
+                    }
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/ExpandedStomach/Hud/HudESBar.cs
+++ b/ExpandedStomach/Hud/HudESBar.cs
@@ -46,7 +46,7 @@ namespace ExpandedStomach.Hud
             ComposeBarGUI(); // call this to make sure bar is fully updated;
         }
 
-        private void ComposeBarGUI()
+        public void ComposeBarGUI()
         {
             if (!_showBar) return;
             const float ESBarParentWidth = 850f;

--- a/ExpandedStomach/StomachSize/EntityBehaviorStomach.cs
+++ b/ExpandedStomach/StomachSize/EntityBehaviorStomach.cs
@@ -30,6 +30,12 @@ namespace ExpandedStomach
         public int overStuffedTimeDelay;
         public float overStuffedThreshold;
 
+        public float fatToBeLostToHunger = 0f;
+        public float totalFatLostToHunger = 0f;
+        public float hungerStavedByFatLoss = 0f;
+        public bool currentlyFendingOffHungerWithFatLoss = false;
+        public float fatLostToHungerMultiplier = 0f;
+
         private static readonly Random rand = new Random();
 
         public override void OnEntityRevive()
@@ -153,7 +159,7 @@ namespace ExpandedStomach
             {
                 float tryFloat = float.IsNaN(value) ? 0f : value;
                 tryFloat = GameMath.Clamp(tryFloat, 0f, 0.4f);
-                if(_movementPenalty != tryFloat)
+                if (_movementPenalty != tryFloat)
                 {
                     _movementPenalty = tryFloat;
                     UpdateWalkSpeed();
@@ -164,7 +170,8 @@ namespace ExpandedStomach
         public float strain
         {
             get => StomachAttributes.GetFloat("strain", 0);
-            set {
+            set
+            {
                 StomachAttributes.SetFloat("strain", value);
                 entity.WatchedAttributes.MarkPathDirty("expandedStomach");
             }
@@ -223,7 +230,7 @@ namespace ExpandedStomach
                 StomachSize /= 2;
             }
             ExpandedStomachMeter = 0;
-            if(entity.Api.World.Config.GetString("ExpandedStomach.difficulty") == "hard")
+            if (entity.Api.World.Config.GetString("ExpandedStomach.difficulty") == "hard")
                 OopsWeDied = true;
         }
 
@@ -273,6 +280,7 @@ namespace ExpandedStomach
             CalculateMovementSpeedPenalty();
             debugmode = entity.World.Config.GetBool("ExpandedStomach.debugMode");
             overStuffedTimeDelay = entity.World.Config.GetInt("ExpandedStomach.overStuffedTimeDelay");
+            fatLostToHungerMultiplier = entity.World.Config.GetFloat("ExpandedStomach.fatLostToHungerMultiplier");
         }
 
         public void ServerTickSUPERSlow(float deltaTime)
@@ -282,7 +290,7 @@ namespace ExpandedStomach
             int today = (int)Math.Floor(entity.World.Calendar.TotalDays);
             if (today > days) // if a day has passed
             {
-                if(OopsWeDied) OopsWeDied = false;
+                if (OopsWeDied) OopsWeDied = false;
                 averagestrain = (averagestrain * 6 + strain) / 7;
                 ExpandedStomachCapAverage = (ExpandedStomachCapAverage * 6 + ExpandedStomachCapToday) / 7;
                 ExpandedStomachCapToday = 0;
@@ -303,7 +311,7 @@ namespace ExpandedStomach
             bool overeating = strain == 1 || strain > laststrain;
             bool maintaining = strain <= laststrain && ExpandedStomachWasActive;
             bool dieting = strain <= laststrain && !ExpandedStomachWasActive;
-            float fatlossChance = 1-strain;
+            float fatlossChance = 1 - strain;
 
             string smessage = "";
             bool immersiveMessages = entity.Api.World.Config.GetBool("ExpandedStomach.immersiveMessages");
@@ -315,9 +323,9 @@ namespace ExpandedStomach
             switch (difficulty)
             {
                 case "easy":
-                    if(increasedifference > 0)
+                    if (increasedifference > 0)
                         increasedifference *= 2;
-                    if(increasedifference < 0)
+                    if (increasedifference < 0)
                         increasedifference /= 2;
                     break;
                 case "hard":
@@ -337,7 +345,7 @@ namespace ExpandedStomach
                 smessage = Lang.Get("expandedstomach:stomachwillshrink");
             }
             StomachSize = newstomachsize;
-            if(newstomachsize > 5500) smessage = Lang.Get("expandedstomach:stomachatmax");
+            if (newstomachsize > 5500) smessage = Lang.Get("expandedstomach:stomachatmax");
             if (difficulty == "easy" || debugmode == true)
             {
                 smessage += "\nStomach size is " + StomachSize.ToString() + " units.";
@@ -407,7 +415,7 @@ namespace ExpandedStomach
                     {
                         if (FatMeterChanged)
                         {
-                            if(smessage != "") smessage += "\n\n";
+                            if (smessage != "") smessage += "\n\n";
                             if (FatMeter >= 0.25 && oldFatMeter < 0.25) smessage += Lang.Get("expandedstomach:bodyfatplus25");
                             if (FatMeter >= 0.5 && oldFatMeter < 0.5) smessage += Lang.Get("expandedstomach:bodyfatplus50");
                             if (FatMeter >= 0.75 && oldFatMeter < 0.75) smessage += Lang.Get("expandedstomach:bodyfatplus75");
@@ -438,7 +446,7 @@ namespace ExpandedStomach
                             if (FatMeter <= 0.5 && oldFatMeter > 0.5) smessage += Lang.Get("expandedstomach:bodyfatminus50");
                             if (FatMeter <= 0.75 && oldFatMeter > 0.75) smessage += Lang.Get("expandedstomach:bodyfatminus75");
                         }
-                        if(!string.IsNullOrEmpty(smessage.Clean().Trim()))
+                        if (!string.IsNullOrEmpty(smessage.Clean().Trim()))
                         {
                             serverPlayer.SendMessage(GlobalConstants.GeneralChatGroup,
                             smessage.Clean(),
@@ -447,7 +455,7 @@ namespace ExpandedStomach
                     }
                     if (debugmode == true)
                     {
-                        smessage += "\nYour fat level is now " + (FatMeter*100).ToString() + "%.";
+                        smessage += "\nYour fat level is now " + (FatMeter * 100).ToString() + "%.";
                         serverPlayer.SendMessage(GlobalConstants.GeneralChatGroup,
                             smessage.Clean(),
                             EnumChatType.Notification);
@@ -494,7 +502,7 @@ namespace ExpandedStomach
             {
                 float newstrain = strain - newdecayrate * 0.5f;
                 newstrain = Math.Clamp(newstrain, 0.5f, 1f);
-                if(newstrain < strain) strain = newstrain;
+                if (newstrain < strain) strain = newstrain;
             }
             if (CurrentSatiety < 1000) // if player is not overeating, assume they're on a diet
             {
@@ -513,19 +521,26 @@ namespace ExpandedStomach
 
         public override void OnEntityReceiveSaturation(float saturation, EnumFoodCategory foodCat = EnumFoodCategory.Unknown, float saturationLossDelay = 10, float nutritionGainMultiplier = 1)
         {
+            //check if stomach is full and they overate a little...or a lot
+            if (CurrentSatiety == MaxSatiety && ExpandedStomachMeter > 0) // + some threshold from the config?)
+            {
+                // reset fat to be lost
+                fatToBeLostToHunger = 0;
+                currentlyFendingOffHungerWithFatLoss = false;
+            }
             //update last time player ate
             float percentfull = ExpandedStomachMeter / StomachSize;
             overStuffedThreshold = entity.Api.World.Config.GetFloat("ExpandedStomach.overStuffedThreshold");
             bool shouldDisplayMessages = shouldMessagesDisplay(entity.Api.World.Config.GetBool("ExpandedStomach.immersiveMessages"),
                                                                entity.Api.World.Config.GetBool("ExpandedStomach.bar"));
-            if (percentfull <= 0 ) return;
+            if (percentfull <= 0) return;
             if (percentfull >= overStuffedThreshold)
                 TriggerStuffedStatus(true);
             if (DateTime.Now > lastrecievedsaturation + TimeSpan.FromSeconds(1) && !OopsWeDied)
             {
                 lastrecievedsaturation = DateTime.Now;
                 //get stomach sat and size and calculate percentage
-                
+
                 if (shouldDisplayMessages && saturation >= 0)
                 {
                     bool messageset = false;
@@ -615,7 +630,7 @@ namespace ExpandedStomach
             {
                 entity.World.UnregisterGameTickListener(stuffedListenerId);
                 stuffedListenerId = entity.World.RegisterGameTickListener(MonitorStomachForOverStuffed, 2000, 0); //2 seconds
-            } 
+            }
         }
 
         private void MonitorStomachForOverStuffed(float obj)
@@ -632,7 +647,7 @@ namespace ExpandedStomach
         public override void OnEntityDespawn(EntityDespawnData despawn)
         {
             base.OnEntityDespawn(despawn);
-            
+
             if (serverListenerId != 0)
             {
                 entity.World.UnregisterGameTickListener(serverListenerId);

--- a/ExpandedStomach/modinfo.json
+++ b/ExpandedStomach/modinfo.json
@@ -7,8 +7,8 @@
     "LadyWYT"
   ],
   "description": "Eat all you want. Finish that last bite...",
-  "version": "1.2.7",
+  "version": "1.3.1-rc.3",
   "dependencies": {
-    "game": "1.21.0"
+    "game": "1.22.0-rc.5"
   }
 }

--- a/HungerPatcher/HungerPatcher/HungryWhileInjuredModSystem.cs
+++ b/HungerPatcher/HungerPatcher/HungryWhileInjuredModSystem.cs
@@ -19,6 +19,7 @@ namespace HungryWhileInjured
         private static bool patched = false;
         ICoreServerAPI theMod;
         private static ILogger ModLogger;
+        private static bool es = false;
 
         public override void StartPre(ICoreAPI api)
         {
@@ -30,6 +31,12 @@ namespace HungryWhileInjured
             theMod = api;
             ModLogger = Mod.Logger;
             Mod.Logger.Notification("Patching serverside...");
+
+            //detect Expanded Stomach mod
+            if (api.ModLoader.IsModEnabled("expandedstomach"))
+            {
+                es = true;
+            }
 
             if (!patched)
             {
@@ -120,6 +127,7 @@ namespace HungryWhileInjured
         {
             float boostedRegen = healthRegenPerGameSecond;
             
+            // Inside the ApplyNutritionToRegenBoost method
             if (hungerBehavior != null) 
             {
                 float fruitBoost = hungerBehavior.FruitLevel / 1500f;
@@ -129,8 +137,28 @@ namespace HungryWhileInjured
                 float dairyBoost = hungerBehavior.DairyLevel / 1500f;
 
                 float boostAmount = (fruitBoost + vegBoost + proteinBoost + grainBoost + dairyBoost) / 100f;
+    
+                // Check if Expanded Stomach mod is enabled
+                if (es)
+                {
+                    // Try to get the stomach size from the entity
+                    var entity = hungerBehavior.entity as EntityPlayer;
+                    // Use reflection to find the EntityBehaviorStomach
+                    var stomachType = Type.GetType("ExpandedStomach.EntityBehaviorStomach, ExpandedStomach");
+                    var stomachBehavior = entity.GetBehavior("expandedStomach");
+
+                    if (stomachBehavior != null)
+                    {
+                        float stomachSize = stomachBehavior.GetType().GetProperty("StomachSize")?.GetValue(stomachBehavior) as float? ?? 0f;
+                        float stomachBoost = stomachSize / 5000f;
+                        boostAmount += stomachBoost;
+                        Console.WriteLine("Added {0} to health.", boostAmount);
+                    }
+                }
+    
                 boostedRegen = healthRegenPerGameSecond * (1f + boostAmount);
             }
+
             return boostedRegen;
         }
     }


### PR DESCRIPTION
Added: hunger damage ticks can be fended off when hungry by burning fat instead.
Fixed: body temperature code moved in the entityBodyTemperature class and would generate a harmony patching error.
Fixed: Commands not recognizing player names when improperly capitalized. Player names are no longer case sensitive.
Fixed: patching issues with server and client-side patches getting mixed and muddled together.

Added detection for Expanded Stomach to Hungry While Injured mod. If ES is active, then HWI will give player a health recovery boost based on stomach size.