### PR TITLE
Add SlowTox mod compatibility (v1.4.1)

### DIFF
--- a/ExpandedStomach/Config/ConfigServer.cs
+++ b/ExpandedStomach/Config/ConfigServer.cs
@@ -68,6 +68,12 @@ namespace ExpandedStomach
         public string fatLostToHungerMultiplierDescription => "Multiply how much fat is lost when fending off hunger. (default 100%)";
         [JsonProperty(Order = 28)]
         public float fatLostToHungerMultiplier { get; set; } = 1f;
+        [JsonProperty(Order = 29)]
+        public string slowToxDescription => "SlowTox compatibility settings. Only active when SlowTox is installed. Fat level scales both alcohol tolerance and how long intoxication lingers.";
+        [JsonProperty(Order = 30)]
+        public float slowToxFatToleranceScale { get; set; } = 0.5f;
+        [JsonProperty(Order = 31)]
+        public float slowToxFatDecayRateScale { get; set; } = 0.5f;
 
         public ConfigServer(ICoreAPI api, ConfigServer previousConfig = null)
         {
@@ -90,6 +96,8 @@ namespace ExpandedStomach
             overStuffedTimeDelay = previousConfig.overStuffedTimeDelay;
             overStuffedThreshold = previousConfig.overStuffedThreshold;
             fatLostToHungerMultiplier = previousConfig.fatLostToHungerMultiplier;
+            slowToxFatToleranceScale = previousConfig.slowToxFatToleranceScale;
+            slowToxFatDecayRateScale = previousConfig.slowToxFatDecayRateScale;
         }
     }
 }

--- a/ExpandedStomach/ExpandedStomachModSystem.cs
+++ b/ExpandedStomach/ExpandedStomachModSystem.cs
@@ -102,6 +102,7 @@ public class ExpandedStomachModSystem : ModSystem
             if (stomachbehavior != null)
             {
                 stomachbehavior.CalculateMovementSpeedPenalty();
+                SlowToxCompat.UpdateEntityForFat(entity, stomachbehavior.FatMeter);
             }
         };
 
@@ -130,6 +131,11 @@ public class ExpandedStomachModSystem : ModSystem
             {
                 HarmonyPatchesVars.IthaniaCannedGoodsInstalled = true;
                 Mod.Logger.Notification("Ithania Canned Goods detected (server-side).");
+            }
+            if (api.ModLoader.IsModEnabled("slowtox"))
+            {
+                SlowToxCompat.Initialize();
+                Mod.Logger.Notification("SlowTox detected (server-side). Fat-based tolerance and decay rate compat enabled.");
             }
             ServerPatcher.ApplyServerPatches(sHarmony);
             Patch_HungerDamageTicks.ApplyCorePatches(sHarmony);

--- a/ExpandedStomach/HarmonyPatches/Patch_SlowTox.cs
+++ b/ExpandedStomach/HarmonyPatches/Patch_SlowTox.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Reflection;
+using HarmonyLib;
+using Vintagestory.API.Common;
+using Vintagestory.API.Common.Entities;
+
+namespace ExpandedStomach.HarmonyPatches
+{
+    /// <summary>
+    /// SlowTox compatibility module.
+    ///
+    /// No Harmony patches are applied here. We interact with SlowTox through
+    /// two mechanisms that avoid any method patching entirely (and therefore
+    /// sidestep JIT-inlining issues that affect other compat patches):
+    ///
+    ///   1. Entity stat "slowtox:tolerance" — writing a named "fatTolerance" key
+    ///      scales how hard it is for a fat player to accumulate intoxication per
+    ///      drink. Higher fat = higher tolerance = harder to get drunk.
+    ///
+    ///   2. Per-entity _config field replacement — SlowTox's SlowToxBehavior holds
+    ///      a private _config field that normally points to the shared
+    ///      ModConfig.Instance.Intoxication singleton. We create a fresh
+    ///      IntoxicationConfig copy for each player and lower its DecayRate in
+    ///      proportion to their fat level. Because SlowTox reads _config.DecayRate
+    ///      inside DigestToxins on every tick, the fat player's intoxication decays
+    ///      more slowly, making the effects linger longer. Thin players are left
+    ///      on the unmodified singleton and sober up at the normal rate.
+    /// </summary>
+    public static class SlowToxCompat
+    {
+        // Cached reflection handles — resolved once in Initialize().
+        private static FieldInfo      _configField;
+        private static PropertyInfo[] _configProps;
+        private static PropertyInfo   _decayRateProp;
+        private static PropertyInfo   _modConfigInstanceProp;
+        private static PropertyInfo   _modConfigIntoxProp;
+
+        public static bool IsActive { get; private set; }
+
+        /// <summary>
+        /// Resolves all SlowTox types and members via reflection.
+        /// Must be called from <see cref="ExpandedStomachModSystem.StartServerSide"/>
+        /// after SlowTox has been confirmed present by the mod loader.
+        /// </summary>
+        public static void Initialize()
+        {
+            try
+            {
+                Type behaviorType = AccessTools.TypeByName("SlowTox.SlowToxBehavior");
+                Type modCfgType   = AccessTools.TypeByName("SlowTox.Config.ModConfig");
+
+                if (behaviorType == null || modCfgType == null)
+                {
+                    ExpandedStomachModSystem.Logger.Error("SlowToxCompat: could not find SlowTox types — compat disabled.");
+                    return;
+                }
+
+                _configField = AccessTools.Field(behaviorType, "_config");
+                if (_configField == null)
+                {
+                    ExpandedStomachModSystem.Logger.Error("SlowToxCompat: could not find SlowToxBehavior._config — compat disabled.");
+                    return;
+                }
+
+                // Derive the IntoxicationConfig type directly from the field rather than
+                // looking it up by name, so a namespace refactor in SlowTox won't break us.
+                Type configType = _configField.FieldType;
+                _configProps   = configType.GetProperties(BindingFlags.Public | BindingFlags.Instance);
+                _decayRateProp = configType.GetProperty("DecayRate");
+                if (_decayRateProp == null)
+                {
+                    ExpandedStomachModSystem.Logger.Error("SlowToxCompat: could not find IntoxicationConfig.DecayRate — compat disabled.");
+                    return;
+                }
+
+                _modConfigInstanceProp = modCfgType.GetProperty("Instance",     BindingFlags.Public | BindingFlags.Static);
+                _modConfigIntoxProp    = modCfgType.GetProperty("Intoxication", BindingFlags.Public | BindingFlags.Instance);
+                if (_modConfigInstanceProp == null || _modConfigIntoxProp == null)
+                {
+                    ExpandedStomachModSystem.Logger.Error("SlowToxCompat: could not find ModConfig.Instance or .Intoxication — compat disabled.");
+                    return;
+                }
+
+                IsActive = true;
+                ExpandedStomachModSystem.Logger.Notification("SlowToxCompat: initialized successfully.");
+            }
+            catch (Exception ex)
+            {
+                ExpandedStomachModSystem.Logger.Error("SlowToxCompat: exception during initialization — " + ex.Message);
+            }
+        }
+
+        /// <summary>
+        /// Updates both the tolerance stat and the per-entity decay rate config
+        /// to reflect the entity's current fat level. Safe to call when
+        /// <see cref="IsActive"/> is false — exits immediately as a no-op.
+        /// </summary>
+        public static void UpdateEntityForFat(Entity entity, float fatMeter)
+        {
+            if (!IsActive) return;
+            UpdateTolerance(entity, fatMeter);
+            UpdateDecayRate(entity, fatMeter);
+        }
+
+        // ── private helpers ──────────────────────────────────────────────────
+
+        private static void UpdateTolerance(Entity entity, float fatMeter)
+        {
+            // "slowtox:tolerance" is a FlatMultiply stat — every registered key's
+            // value is multiplied together. A multiplier of 1.0 is neutral.
+            // We scale linearly from 1.0 at fat 0 up to (1 + scale) at fat 1.
+            float scale      = ExpandedStomachModSystem.sConfig?.slowToxFatToleranceScale ?? 0.5f;
+            float multiplier = 1f + fatMeter * scale;
+            entity.Stats.Set("slowtox:tolerance", "fatTolerance", multiplier, persistent: true);
+        }
+
+        private static void UpdateDecayRate(Entity entity, float fatMeter)
+        {
+            EntityBehavior behavior = entity.GetBehavior("slowtox");
+            if (behavior == null) return; // SlowTox not active on this entity yet
+
+            // Re-fetch the canonical base config on every call so that any
+            // server-side SlowTox config reloads are always honoured.
+            object modConfigInstance = _modConfigInstanceProp.GetValue(null);
+            if (modConfigInstance == null) return;
+            object baseConfig = _modConfigIntoxProp.GetValue(modConfigInstance);
+            if (baseConfig == null) return;
+
+            // Build a fresh per-entity copy of IntoxicationConfig, starting with
+            // a verbatim copy of all properties from the live singleton.
+            object newConfig = Activator.CreateInstance(_configField.FieldType);
+            foreach (PropertyInfo prop in _configProps)
+            {
+                if (prop.CanWrite)
+                    prop.SetValue(newConfig, prop.GetValue(baseConfig));
+            }
+
+            // Reduce decay rate proportionally to fat level.
+            //   fatMeter = 0.0 → decayRate unchanged (no effect on thin players)
+            //   fatMeter = 1.0 → decayRate × (1 - scale)
+            // Floored at 10 % of base so intoxication can never become permanent
+            // even at max fat.
+            float scale    = ExpandedStomachModSystem.sConfig?.slowToxFatDecayRateScale ?? 0.5f;
+            float baseRate = (float)_decayRateProp.GetValue(baseConfig);
+            float adjusted = baseRate * (1f - fatMeter * scale);
+            adjusted       = MathF.Max(adjusted, baseRate * 0.1f);
+            _decayRateProp.SetValue(newConfig, adjusted);
+
+            // Assign the personalised config to this entity's SlowToxBehavior.
+            // All other players' behaviors still reference the shared singleton.
+            _configField.SetValue(behavior, newConfig);
+        }
+    }
+}

--- a/ExpandedStomach/StomachSize/EntityBehaviorStomach.cs
+++ b/ExpandedStomach/StomachSize/EntityBehaviorStomach.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using ExpandedStomach.HarmonyPatches;
 using Vintagestory.API.Common;
 using Vintagestory.API.Datastructures;
 using Vintagestory.API.Common.Entities;
@@ -132,6 +133,7 @@ namespace ExpandedStomach
         {
             FatMeter = value;
             CalculateMovementSpeedPenalty();
+            SlowToxCompat.UpdateEntityForFat(entity, FatMeter);
         }
 
         public float MaxSatiety //just an accessor for base game
@@ -472,6 +474,7 @@ namespace ExpandedStomach
             }
 
             bool FatMeterChanged = FatMeter.isDifferent(oldFatMeter);
+            if (FatMeterChanged) SlowToxCompat.UpdateEntityForFat(entity, FatMeter);
 
             switch (entity.Api.World.Config.GetString("ExpandedStomach.difficulty"))
             {

--- a/ExpandedStomach/modinfo.json
+++ b/ExpandedStomach/modinfo.json
@@ -7,7 +7,7 @@
     "LadyWYT"
   ],
   "description": "Eat all you want. Finish that last bite...",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "dependencies": {
     "game": ""
   }


### PR DESCRIPTION
  Title: Add SlowTox compatibility (v1.4.1)

  Body:
  ## Summary

  - Add `Patch_SlowTox.cs`: reflection-based compatibility module that adjusts SlowTox behavior based on the player's
  fat level, with no Harmony patches required
    - Fat level scales `slowtox:tolerance` stat — fatter players accumulate intoxication more slowly
    - Fat level reduces `DecayRate` on a per-entity config copy — intoxication lingers longer for fatter players
  - Add `slowToxFatToleranceScale` and `slowToxFatDecayRateScale` to server config for server admin tuning
  - Detect SlowTox at startup and call `SlowToxCompat.Initialize()` to resolve types/members via reflection once
  - Call `SlowToxCompat.UpdateEntityForFat` on player join, `SetFatMeter`, and daily fat rollover to keep SlowTox in
  sync with fat changes
  - Bump version to 1.4.1

  ## Test plan

  - [x] Verify SlowTox is detected and compat initialized on server startup (check log notification)
  - [x] Verify fat player has higher intoxication tolerance (takes more drinks to get drunk)
  - [x] Verify fat player takes longer to sober up than a lean player after equivalent drinking
  - [x] Verify lean player (fat = 0) is unaffected — uses unmodified SlowTox singleton config
  - [x] Verify compat gracefully disables if SlowTox types/members can't be found (no crash)
  - [x] Verify no regression when SlowTox is not installed